### PR TITLE
fix for html entity in title element RSS feed #40558

### DIFF
--- a/libraries/src/MVC/View/CategoryFeedView.php
+++ b/libraries/src/MVC/View/CategoryFeedView.php
@@ -86,7 +86,7 @@ class CategoryFeedView extends HtmlView
             // Strip html from feed item title
             if ($titleField) {
                 $title = $this->escape($item->$titleField);
-                $title = html_entity_decode($title, ENT_COMPAT, 'UTF-8');
+                $title = html_entity_decode($title, ENT_QUOTES, 'UTF-8');
             } else {
                 $title = '';
             }


### PR DESCRIPTION
Pull Request for Issue #40558 .

Since J4 the escape function in \libraries\src\MVC\View\HtmlView.php - Line 233 includes single quotes by passing the ENT_QUOTES flag to htmlspecialchars()

The escape method is used to strip html from the feed item title by first escaping the item title.
Then the title is decoded by html_entity_decode using the ENT_COMPAT flag
This causes the html-single-quote-entity (&#039;) to remain in the title.

I guess the title is amp_replaced on parsing the rss feed causing the `&#039;` to become `&amp;#039;` in the final output.

### Steps to reproduce the issue
Create an article in category EXAMPLE (category id = 1)  with single quotes in the title.
title = This is a 'test' article

Display a feed from this category index.php?option=com_content&view=category&id=1&format=feed&type=rss

### Expected result
Well formed RSS feed which shows this title element:
`<title>This is a 'test' article</title>`

### Actual result
`<title>This is a &amp;#039;test&amp;#039; article</title>`


### System information (as much as possible)
Joomla 4.3.1
PHP 8.1.10


### Additional comments
Changing the flag to ENT_QUOTES in the html_entity_decode function fixes the issue.

Current situation:
```
$title = "This is a 'test' article";

$title = htmlspecialchars($title, ENT_QUOTES, 'UTF-8');
echo $title;

$title = html_entity_decode($title, ENT_COMPAT, 'UTF-8');
echo $title;

This is a &#039;test&#039; article
This is a &#039;test&#039; article
```

Fixed:
```
$title = "This is a 'test' article";

$title = htmlspecialchars($title, ENT_QUOTES, 'UTF-8');
echo $title;

$title = html_entity_decode($title, ENT_QUOTES, 'UTF-8');
echo $title;

This is a &#039;test&#039; article
This is a 'test' article
```